### PR TITLE
add-secret-for-GITHUB_OAUTH_TOKEN-and-update-image

### DIFF
--- a/kubectl_deploy/deployment.yaml
+++ b/kubectl_deploy/deployment.yaml
@@ -13,25 +13,25 @@ spec:
         app: cp-metrics-app
     spec:
       containers:
-      - name: cp-metrics-app
-        image: ministryofjustice/cloud-platform-metrics:1.3
-        ports:
-        - containerPort: 8080
-        env:
-        - name: AWS_REGION
-          value: eu-west-2
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: cp-metrics-aws-costs
-              key: access_key_id
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: cp-metrics-aws-costs
-              key: secret_access_key
-        - name: GITHUB_OAUTH_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: cloud-platform-metrics-github-token
-              key: token
+        - name: cp-metrics-app
+          image: ministryofjustice/cloud-platform-metrics:1.3
+          ports:
+            - containerPort: 8080
+          env:
+            - name: AWS_REGION
+              value: eu-west-2
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cp-metrics-aws-costs
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cp-metrics-aws-costs
+                  key: secret_access_key
+            - name: GITHUB_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-platform-metrics-github-token
+                  key: token

--- a/kubectl_deploy/deployment.yaml
+++ b/kubectl_deploy/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: cp-metrics-app
-        image: poornimak/cloud-platform-metrics:1.1
+        image: ministryofjustice/cloud-platform-metrics:1.3
         ports:
         - containerPort: 8080
         env:
@@ -30,3 +30,8 @@ spec:
             secretKeyRef:
               name: cp-metrics-aws-costs
               key: secret_access_key
+        - name: GITHUB_OAUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: cloud-platform-metrics-github-token
+              key: token


### PR DESCRIPTION
Why:
GITHUB_OAUTH_TOKEN secret not set. Image now in ministry-of-justice:
Proof that now working:
https://prometheus.live.cloud-platform.service.justice.gov.uk/graph?g0.expr=cloud_platform_metrics_infrastructure_deployment_details_deployed&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h