### PR TITLE
add-infrastructure-deployments-grafana-chart

### DIFF
--- a/kubectl_deploy/dashboard-cloud-platform-infrastructure-deployments-metrics.yaml
+++ b/kubectl_deploy/dashboard-cloud-platform-infrastructure-deployments-metrics.yaml
@@ -1,0 +1,319 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: infrastructure-deployments-metrics
+  namespace: cloud-platform-metrics
+  labels:
+    grafana_dashboard: ""
+data:
+  dashboard-infrastructure-deployments-metrics.json: |
+    {
+    	"annotations": {
+    		"list": [{
+    			"builtIn": 1,
+    			"datasource": "-- Grafana --",
+    			"enable": true,
+    			"hide": true,
+    			"iconColor": "rgba(0, 211, 255, 1)",
+    			"name": "Annotations & Alerts",
+    			"type": "dashboard"
+    		}]
+    	},
+    	"description": "Visualize estimated infrastructure PR Successful/Failed",
+    	"editable": false,
+    	"gnetId": 139,
+    	"graphTooltip": 0,
+    	"id": null,
+    	"iteration": 1614364548685,
+    	"links": [],
+    	"panels": [{
+    			"aliasColors": {},
+    			"bars": false,
+    			"dashLength": 10,
+    			"dashes": false,
+    			"datasource": "Thanos",
+    			"editable": true,
+    			"error": false,
+    			"fieldConfig": {
+    				"defaults": {
+    					"custom": {},
+    					"links": []
+    				},
+    				"overrides": []
+    			},
+    			"fill": 1,
+    			"fillGradient": 0,
+    			"grid": {},
+    			"gridPos": {
+    				"h": 15,
+    				"w": 24,
+    				"x": 0,
+    				"y": 0
+    			},
+    			"hiddenSeries": false,
+    			"id": 1,
+    			"isNew": true,
+    			"legend": {
+    				"alignAsTable": true,
+    				"current": true,
+    				"hideEmpty": false,
+    				"hideZero": false,
+    				"show": true,
+    				"sort": "current",
+    				"sortDesc": true,
+    				"total": false,
+    				"values": true
+    			},
+    			"lines": true,
+    			"linewidth": 2,
+    			"links": [],
+    			"nullPointMode": "connected",
+    			"options": {
+    				"alertThreshold": true
+    			},
+    			"percentage": false,
+    			"pluginVersion": "7.5.9",
+    			"pointradius": 5,
+    			"points": false,
+    			"renderer": "flot",
+    			"seriesOverrides": [],
+    			"spaceLength": 10,
+    			"stack": true,
+    			"steppedLine": true,
+    			"targets": [{
+    				"expr": "sum (cloud_platform_metrics_infrastructure_deployment_details_deployed)",
+    				"application": {
+    					"filter": ""
+    				},
+    				"expression": "",
+    				"functions": [],
+    				"group": {
+    					"filter": ""
+    				},
+    				"highResolution": false,
+    				"host": {
+    					"filter": ""
+    				},
+    				"id": "",
+    				"item": {
+    					"filter": ""
+    				},
+    				"matchExact": true,
+    				"metricName": "Successful Infrastructure deployments",
+    				"mode": 0,
+    				"namespace": "monitoring",
+    				"options": {
+    					"showDisabledItems": false
+    				},
+    				"period": "",
+    				"refId": "A",
+    				"returnData": false,
+    				"statistics": [
+    					"Average"
+    				]
+    			}],
+    			"thresholds": [],
+    			"timeFrom": null,
+    			"timeRegions": [],
+    			"timeShift": null,
+    			"title": "Cloud Platform Successful Infrastructure Deployments",
+    			"tooltip": {
+    				"msResolution": false,
+    				"shared": true,
+    				"sort": 2,
+    				"value_type": "cumulative"
+    			},
+    			"type": "graph",
+    			"xaxis": {
+    				"buckets": null,
+    				"mode": "time",
+    				"name": null,
+    				"show": true,
+    				"values": []
+    			},
+                        "yaxes": [{
+                                        "label": null,
+                                        "logBase": 1,
+                                        "show": true
+                                },
+                                {
+                                        "format": "short",
+                                        "label": null,
+                                        "logBase": 1,
+                                        "show": false
+                                }
+                        ],
+                        "yaxis": {
+                                "decimals": 0,
+    				"align": false,
+    				"alignLevel": null
+    			}
+    		},
+    		{
+    			"aliasColors": {},
+    			"bars": false,
+    			"dashLength": 10,
+    			"dashes": false,
+    			"datasource": "Thanos",
+    			"editable": true,
+    			"error": false,
+    			"fieldConfig": {
+    				"defaults": {
+    					"custom": {},
+    					"links": []
+    				},
+    				"overrides": []
+    			},
+    			"fill": 1,
+    			"fillGradient": 0,
+    			"grid": {},
+    			"gridPos": {
+    				"h": 15,
+    				"w": 24,
+    				"x": 0,
+    				"y": 0
+    			},
+    			"hiddenSeries": false,
+    			"id": 1,
+    			"isNew": true,
+    			"legend": {
+    				"alignAsTable": true,
+    				"current": true,
+    				"hideEmpty": false,
+    				"hideZero": false,
+    				"show": true,
+    				"sort": "current",
+    				"sortDesc": true,
+    				"total": false,
+    				"values": true
+    			},
+    			"lines": true,
+    			"linewidth": 2,
+    			"links": [],
+    			"nullPointMode": "connected",
+    			"options": {
+    				"alertThreshold": true
+    			},
+    			"percentage": false,
+    			"pluginVersion": "7.5.9",
+    			"pointradius": 5,
+    			"points": false,
+    			"renderer": "flot",
+    			"seriesOverrides": [],
+    			"spaceLength": 10,
+    			"stack": true,
+    			"steppedLine": true,
+    			"targets": [{
+    				"expr": "sum (cloud_platform_metrics_infrastructure_deployment_details_failed)",
+    				"application": {
+    					"filter": ""
+    				},
+    				"expression": "",
+    				"functions": [],
+    				"group": {
+    					"filter": ""
+    				},
+    				"highResolution": false,
+    				"host": {
+    					"filter": ""
+    				},
+    				"id": "",
+    				"item": {
+    					"filter": ""
+    				},
+    				"matchExact": true,
+    				"metricName": "Failed Infrastructure deployments",
+    				"mode": 0,
+    				"namespace": "monitoring",
+    				"options": {
+    					"showDisabledItems": false
+    				},
+    				"period": "",
+    				"refId": "A",
+    				"returnData": false,
+    				"statistics": [
+    					"Average"
+    				]
+    			}],
+    			"thresholds": [],
+    			"timeFrom": null,
+    			"timeRegions": [],
+    			"timeShift": null,
+    			"title": "Cloud Platform Failed Infrastructure Deployments",
+    			"tooltip": {
+    				"msResolution": false,
+    				"shared": true,
+    				"sort": 2,
+    				"value_type": "cumulative"
+    			},
+    			"type": "graph",
+    			"xaxis": {
+    				"buckets": null,
+    				"mode": "time",
+    				"name": null,
+    				"show": true,
+    				"values": []
+    			},
+                        "yaxes": [{
+                                        "label": null,
+                                        "logBase": 1,
+                                        "show": true
+                                },
+                                {
+                                        "format": "short",
+                                        "label": null,
+                                        "logBase": 1,
+                                        "show": false
+                                }
+                        ],
+                        "yaxis": {
+                                "decimals": 0,
+    				"align": false,
+    				"alignLevel": null
+    			}
+    		}
+
+    	],
+    	"refresh": false,
+    	"schemaVersion": 27,
+    	"style": "dark",
+    	"tags": [
+    		"metrics",
+    		"monitoring"
+    	],
+
+    	"time": {
+    		"from": "now-7d",
+    		"to": "now"
+    	},
+    	"timepicker": {
+    		"refresh_intervals": [
+    			"5s",
+    			"10s",
+    			"30s",
+    			"1m",
+    			"5m",
+    			"15m",
+    			"30m",
+    			"1h",
+    			"2h",
+    			"1d"
+    		],
+    		"time_options": [
+    			"5m",
+    			"15m",
+    			"1h",
+    			"6h",
+    			"12h",
+    			"24h",
+    			"2d",
+    			"7d",
+    			"30d"
+    		]
+    	},
+    	"timezone": "browser",
+    	"title": "infrastructure_deploymemts_metrics",
+    	"uid": "infrastructure_deployments_metrics",
+    	"version": 1
+    }

--- a/kubectl_deploy/deployment.yaml
+++ b/kubectl_deploy/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: cp-metrics-app
-          image: poornimak/cloud-platform-metrics:1.1
+          image: ministryofjustice/cloud-platform-metrics:1.3
           ports:
             - containerPort: 8080
           env:
@@ -30,3 +30,8 @@ spec:
                 secretKeyRef:
                   name: cp-metrics-aws-costs
                   key: secret_access_key
+            - name: GITHUB_OAUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloud-platform-metrics-github-token
+                  key: token

--- a/kubectl_deploy/deployment.yaml
+++ b/kubectl_deploy/deployment.yaml
@@ -13,20 +13,20 @@ spec:
         app: cp-metrics-app
     spec:
       containers:
-      - name: cp-metrics-app
-        image: poornimak/cloud-platform-metrics:1.1
-        ports:
-        - containerPort: 8080
-        env:
-        - name: AWS_REGION
-          value: eu-west-2
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: cp-metrics-aws-costs
-              key: access_key_id
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: cp-metrics-aws-costs
-              key: secret_access_key
+        - name: cp-metrics-app
+          image: poornimak/cloud-platform-metrics:1.1
+          ports:
+            - containerPort: 8080
+          env:
+            - name: AWS_REGION
+              value: eu-west-2
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cp-metrics-aws-costs
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cp-metrics-aws-costs
+                  key: secret_access_key


### PR DESCRIPTION
Why:
[Next steps for Cloud Platform metrics#4432](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4432)

and
Grafana dashboard (@AntonyBishop -please see dashboard -only 1 day's worth of data in there so far, 14 successful deployments, 0 failed deployments - tallies with verified commits - excluding dependabot[bot] https://github.com/ministryofjustice/cloud-platform-infrastructure/commits/main):


https://grafana.live.cloud-platform.service.justice.gov.uk/d/infrastructure_deployments_metrics/infrastructure_deploymemts_metrics?orgId=1&from=now-7d&to=now
