### PR TITLE
Use AWS Secrets Manager to store secret

### DIFF
--- a/kubectl_deploy/deployment.yaml
+++ b/kubectl_deploy/deployment.yaml
@@ -33,5 +33,5 @@ spec:
             - name: GITHUB_OAUTH_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: cloud-platform-metrics-github-token
+                  name: cloud-platform-metrics-gh-token
                   key: token


### PR DESCRIPTION
Use AWS Secrets Manager to store gh token secret instead of manual secret